### PR TITLE
Allow plugin reload from console

### DIFF
--- a/src/main/java/me/woodsmc/deathchest/command/DeathChestCommand.java
+++ b/src/main/java/me/woodsmc/deathchest/command/DeathChestCommand.java
@@ -33,7 +33,9 @@ public class DeathChestCommand implements CommandExecutor {
             }
 
         }else{
-            sender.sendMessage("§cOnly players may execute this command!");
+            plugin.reloadConfig();
+            this.string = this.plugin.getConfig().getString("reload-message");
+            System.out.println(this.plugin.getName() + " " + string);
         }
 
         return true;


### PR DESCRIPTION
This small change, allows players to reload the plugin from the console, making it easier for some users by not making it a "requirement" to be on the server to reload the plugin.